### PR TITLE
remove hard version set on vpc module

### DIFF
--- a/rosa-hcp-terraform/setup-vpc.tf
+++ b/rosa-hcp-terraform/setup-vpc.tf
@@ -42,7 +42,6 @@ provider "aws" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
 
   name = "${var.cluster_name}-vpc"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
VPC module was set to version = "3.14.2" which supports classiclink. But with AWS deprecation of that, and the release of the 5.0.0. version of the AWS module, this is no longer compatible and fails to create the rosa plan. Removing it.